### PR TITLE
fix

### DIFF
--- a/pkgs/bin/pkg/config/ix.sh
+++ b/pkgs/bin/pkg/config/ix.sh
@@ -1,8 +1,8 @@
 {% extends '//die/c/autohell.sh' %}
 
 {% block fetch %}
-#https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz
-http://distfiles.gentoo.org/distfiles/pkg-config-0.29.2.tar.gz
+https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz
+#http://distfiles.gentoo.org/distfiles/pkg-config-0.29.2.tar.gz
 sha:6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
 {% endblock %}
 


### PR DESCRIPTION
fetching from gentoo distfiles returns 404 error, looks like gentoo deleted pkgconfig a long time ago
https://archives.gentoo.org/gentoo-dev/message/5bbcef65292c2a92a76cf424c838cbd9