### PR TITLE
Fix gentoo distfiles

### DIFF
--- a/pkgs/bin/pkg/config/ix.sh
+++ b/pkgs/bin/pkg/config/ix.sh
@@ -1,8 +1,8 @@
 {% extends '//die/c/autohell.sh' %}
 
 {% block fetch %}
-https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz
-#http://distfiles.gentoo.org/distfiles/pkg-config-0.29.2.tar.gz
+#https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz
+http://distfiles.gentoo.org/distfiles/d3/pkg-config-0.29.2.tar.gz
 sha:6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
 {% endblock %}
 

--- a/pkgs/lib/display/info/ix.sh
+++ b/pkgs/lib/display/info/ix.sh
@@ -3,7 +3,7 @@
 {% block fetch %}
 #https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/0.1.1/libdisplay-info-0.1.1.tar.bz2
 #sha:51cdb0362882ca2af62532ab4d95e60d81e9890b339264719fd55f8e3945d695
-http://distfiles.gentoo.org/distfiles/libdisplay-info-0.1.1.tar.xz
+http://distfiles.gentoo.org/distfiles/a4/libdisplay-info-0.1.1.tar.xz
 sha:0d8731588e9f82a9cac96324a3d7c82e2ba5b1b5e006143fefe692c74069fb60
 {% endblock %}
 

--- a/pkgs/lib/input/t/ix.sh
+++ b/pkgs/lib/input/t/ix.sh
@@ -1,7 +1,7 @@
 {% extends '//die/c/meson.sh' %}
 
 {% block fetch %}
-http://distfiles.gentoo.org/distfiles/libinput-1.24.0.tar.bz2
+http://distfiles.gentoo.org/distfiles/85/libinput-1.24.0.tar.bz2
 #https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.24.0/libinput-1.24.0.tar.bz2
 sha:c07cd0f3f464e8d2e07dc9479fd5b9340e637408517b77e7e96b2245f37f6fe6
 {% endblock %}

--- a/pkgs/lib/pciaccess/ix.sh
+++ b/pkgs/lib/pciaccess/ix.sh
@@ -3,7 +3,7 @@
 {% block fetch %}
 #https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.17/libpciaccess-libpciaccess-0.17.tar.bz2
 #sha:6e6d69d3cf5ee294dcb38ccfb360f1895a263df5dd8058563cdee62d9b9c17fd
-http://distfiles.gentoo.org/distfiles/libpciaccess-0.17.tar.xz
+http://distfiles.gentoo.org/distfiles/71/libpciaccess-0.17.tar.xz
 sha:74283ba3c974913029e7a547496a29145b07ec51732bbb5b5c58d5025ad95b73
 {% endblock %}
 

--- a/pkgs/lib/pipeline/ix.sh
+++ b/pkgs/lib/pipeline/ix.sh
@@ -1,7 +1,7 @@
 {% extends '//die/c/autorehell.sh' %}
 
 {% block fetch %}
-http://distfiles.gentoo.org/distfiles/libpipeline-1.5.7.tar.gz
+http://distfiles.gentoo.org/distfiles/3b/libpipeline-1.5.7.tar.gz
 sha:b8b45194989022a79ec1317f64a2a75b1551b2a55bea06f67704cb2a2e4690b0
 {% endblock %}
 


### PR DESCRIPTION
gentoo distfiles changed layout from http://distfiles.gentoo.org/distfiles/package to 
http://distfiles.gentoo.org/distfiles/xx/package
where xx is printf '%s' package | b2sum | cut -c1-2