### PR TITLE
Disable htpp in libxml by default and enable static linking for windows

### DIFF
--- a/pkgs/lib/xml/2/t/ix.sh
+++ b/pkgs/lib/xml/2/t/ix.sh
@@ -12,10 +12,11 @@ lib/iconv
 
 {% block configure_flags %}
 --with-ftp=off
---with-http=off
+--with-http=no
 --with-modules=off
 --disable-python
 --without-python
 --with-legacy
 --with-sax1
+--enable_shared=xno
 {% endblock %}


### PR DESCRIPTION
Fix http disabling. In [upstream](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/configure.ac#L537) we can see comparing with "no"
```
if test "$with_http" = "no" ; then
    echo Disabling HTTP support
    WITH_HTTP=0
else
    WITH_HTTP=1
fi
```
And [enable](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/configure.ac#L508) static linking on windows
```
if test "x$enable_shared" = "xno"; then
    XML_CFLAGS="$XML_CFLAGS -DLIBXML_STATIC"
    AM_CFLAGS="$AM_CFLAGS -DLIBXML_STATIC"
fi
```