### PR TITLE
Make {{error(...)}} work

### DIFF
--- a/core/render_ctx.py
+++ b/core/render_ctx.py
@@ -81,6 +81,9 @@ class RenderContext:
     def intro(self, p):
         return self.package.load_package(p, self.package.flags)
 
+    def error(self, msg):
+        raise ce.Error(msg)
+
     def template(self, path):
         pkg = self.package
 

--- a/pkgs/bld/boot/0/ind/ix.sh
+++ b/pkgs/bld/boot/0/ind/ix.sh
@@ -7,7 +7,7 @@
   {% elif ix_boot_tool('g++') %}
     bin/gcc/env/sys
   {% else %}
-    {{error('can not find suitable bootstrap compiler')}}
+    {{ix.error('can not find suitable bootstrap compiler')}}
   {% endif %}
 {% else %}
 # not bootstrap tools for fake runner

--- a/pkgs/bld/boot/3/cc/ix.sh
+++ b/pkgs/bld/boot/3/cc/ix.sh
@@ -10,7 +10,7 @@ mkdir ${out}/bin
 {% if ix_boot_tool('clang++') %}
 {% for x in ['clang', 'clang++', 'clang-cpp', 'llvm-ar', 'llvm-nm', 'llvm-ranlib'] %}
 {% if not ix_boot_tool(x) %}
-{{error(x + ' not in path')}}
+{{ix.error(x + ' not in path')}}
 {% endif %}
 cat << EOF > ${out}/bin/{{x}}
 #!/usr/bin/env sh
@@ -20,7 +20,7 @@ EOF
 {% elif ix_boot_tool('g++') %}
 {% for x in ['gcc', 'g++', 'ar', 'nm', 'ranlib', 'as', 'ld', 'cpp'] %}
 {% if not ix_boot_tool(x) %}
-{{error(x + ' not in path')}}
+{{ix.error(x + ' not in path')}}
 {% endif %}
 cat << EOF > ${out}/bin/{{x}}
 #!/usr/bin/env sh
@@ -28,7 +28,7 @@ exec {{ix_boot_tool(x)}} "\${@}"
 EOF
 {% endfor %}
 {% else %}
-error('shit happen')
+{{ix.error('shit happen')}}
 {% endif %}
 chmod +x ${out}/bin/*
 {% endblock%}


### PR DESCRIPTION
Before:
```
> ix build some_package
UndefinedError: 'error' is undefined
can not render bld/boot/3/cc/ix.sh
```

After:
```
> ix build some_package
Error: clang-cpp not in path
can not render bld/boot/3/cc/ix.sh
```

I have no idea how that was supposed to work originally, so feel free to make a better fix if I got this wrong.