### PR TITLE
Check for lld when bootstrapping with clang

### DIFF
--- a/pkgs/bld/boot/3/cc/ix.sh
+++ b/pkgs/bld/boot/3/cc/ix.sh
@@ -8,7 +8,7 @@ bld/boot/2/env
 echo "{{ix_boot_path}}"
 mkdir ${out}/bin
 {% if ix_boot_tool('clang++') %}
-{% for x in ['clang', 'clang++', 'clang-cpp', 'llvm-ar', 'llvm-nm', 'llvm-ranlib'] %}
+{% for x in ['clang', 'clang++', 'clang-cpp', 'llvm-ar', 'llvm-nm', 'llvm-ranlib', 'lld'] %}
 {% if not ix_boot_tool(x) %}
 {{ix.error(x + ' not in path')}}
 {% endif %}


### PR DESCRIPTION
At least on NixOS and Alpine, you can have `clang` installed without `lld`, however `-fuse-ld=lld` is applied unconditionally when bootstrapping with `clang`. Without `lld` installed, this unsurprisingly fails:
```
...
+ cc -fcolor-diagnostics -nostdinc -nostdinc++ '-D__STDC_ISO_10646__=201505L' -iquote /ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4/arch/x86_64 -iquote /ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4/src/internal -isystem /ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4/arch/x86_64 -isystem /ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4/arch/generic -isystem /ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4/src/include -isystem /ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4/src/internal -isystem /ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4/include -Wno-deprecated -Wno-implicit-int -Wno-int-conversion -Wno-unused-command-line-argument -fno-stack-protector -nostdlib -nostdlib++ -nostdlib++ '-fuse-ld=lld' -static -nostdlib -L/ix/store/FotN4BBdkC4NTGnNEbF7z2-lib-boot-1-lib-musl/musl-1.2.4 -lmusl -Wl,-z,noexecstack cat.c -o cat
clang: error: invalid linker name in argument '-fuse-ld=lld'
ERROR /ix/store/iraG7Wn5xImD2hwnINpDN3-bin-boot-2-shutil
```

Fix this by adding `lld` to a list of tools required to bootstrap with `clang`.