### PR TITLE
Stop looking for Perl libraries in system directories

### DIFF
--- a/pkgs/bin/perl/host/ix.sh
+++ b/pkgs/bin/perl/host/ix.sh
@@ -50,16 +50,21 @@ sed -e 's|/lib/libc|/xxx/libc|g' \
 {% endblock %}
 
 {% block configure %}
-bash Configure -des    \
-    -Dusethreads       \
-    -Dprefix="${out}"  \
-    -Duseperlio        \
-    -Uusesfio          \
-    -Duseshrplib=false \
-    -Dusedl=false      \
-    -Duselibc=c        \
-    -Dlibc=c           \
-    -Dcc=clang
+bash Configure -des        \
+    -Dusethreads           \
+    -Dprefix="${out}"      \
+    -Duseperlio            \
+    -Uusesfio              \
+    -Duseshrplib=false     \
+    -Dusedl=false          \
+    -Duselibc=c            \
+    -Dlibc=c               \
+    -Dcc=clang             \
+    -Dglibpth="/nowhere"   \
+    -Dplibpth="/nowhere"   \
+    -Dxlibpth="/nowhere"   \
+    -Dlocincpth="/nowhere" \
+    -Dloclibpth="/nowhere"
 
 sed -e 's|/.*/bin/sh|/bin/sh|' -e 's|/.*/bin/sed|sed|' -i config.h
 


### PR DESCRIPTION
As of right now, the Perl `Configure` script searches for libraries in `/usr/lib/...` and `/lib/...`. For Alpine with the [gcompat](https://pkgs.alpinelinux.org/package/edge/main/x86_64/gcompat) package installed, the configure script finds these symlinks that point to `/lib/libgcompat.so.0`:
```
Extracting names from the following files for later perusal:
...
        /lib/libcrypt.so.1
        /lib/libm.so.6
        /lib/libpthread.so.0
        /lib/libutil.so.1
...
```

This makes Perl think that some functions (such as `getgrent_r()`) are present in the system libc, while in fact they are absent in `musl` bundled with IX:
```
reentr.c:487:30: error: call to undeclared function 'getgrent_r'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  487 |                     retptr = getgrent(); break;
      |                              ^
./reentr.h:996:52: note: expanded from macro 'getgrent'
  996 | #        define getgrent() ((PL_reentrant_retint = getgrent_r(&PL_reentrant_buffer->_grent_struct, PL_reentrant_buffer->_grent_buffer, PL_reentrant_buffer->_grent_size, &PL_reentrant_buffer->_grent_ptr)) == 0 ? PL_reentrant_buffer->_grent_ptr : ((PL_reentrant_retint == ERANGE) ? (struct group *) Perl_reentrant_retry("getgrent") : 0))
      |                                                    ^
reentr.c:487:30: note: did you mean 'getgrent'?
```

There were [previous attempts](https://github.com/pg83/ix/commit/97b6735ce210ab2e7c048a9a610e91351976709d) to make the perl build hermetic by applying regexps to `Configure`, but they were incomplete for at least two reasons:
  1. The regexps themselves are lacking (e.g., they don't prevent `/lib/...`-like paths from appearing in the search path).
  2. Some of the paths actually come from the hint files bundled with Perl (such as [this one](https://github.com/Perl/perl5/blob/5b9aabc0af37693cb16ea02f35aa054c9684e12c/hints/linux.sh#L202)), not from `Configure` itself.

From looking both at the generated `config.sh` (`Configure -E...`) and [this fragment](https://github.com/Perl/perl5/blob/5b9aabc0af37693cb16ea02f35aa054c9684e12c/Configure#L4957-L4986), my impression is that the logic of populating `$libpth` from the `clang` output is fine (it only contains the `/ix/...` paths, which is what we want). However, the problematic search paths come from the additional `$*libpth` variables that augment `$libpth` with various unwanted directories, such as `/lib/...`, `/usr/lib/...`, `/opt/...`, etc.

Thankfully, we can redefine all of them to `/nowhere` before running `Configure`, which is exactly what this PR does (I also got rid of `$locincpth` just in case, even though the includes appear to be fine).

After this change, this is the full list of libraries `Configure` finds in exactly the same Alpine setup (this hopefully means the build is now hermetic):
```
Extracting names from the following files for later perusal:
        /ix/store/h7MFIjDaXv2qrydWjnvb45-lib-musl-naked-unwrap/lib/libc.a
        /ix/store/h7MFIjDaXv2qrydWjnvb45-lib-musl-naked-unwrap/lib/libcrypt.a
        /ix/store/h7MFIjDaXv2qrydWjnvb45-lib-musl-naked-unwrap/lib/libdl.a
        /ix/store/h7MFIjDaXv2qrydWjnvb45-lib-musl-naked-unwrap/lib/libm.a
        /ix/store/h7MFIjDaXv2qrydWjnvb45-lib-musl-naked-unwrap/lib/libpthread.a
        /ix/store/h7MFIjDaXv2qrydWjnvb45-lib-musl-naked-unwrap/lib/libutil.a
        /ix/store/hXvgoIjyvDUSAml9bqKo63-lib-gdbm-boot/lib/libdbm.a
        /ix/store/hXvgoIjyvDUSAml9bqKo63-lib-gdbm-boot/lib/libgdbm.a
        /ix/store/hXvgoIjyvDUSAml9bqKo63-lib-gdbm-boot/lib/libgdbm_compat.a
```