### PR TITLE
Fix bootstrapping with GCC 13

### DIFF
--- a/pkgs/bld/boot/8/lib/cxx/ix.sh
+++ b/pkgs/bld/boot/8/lib/cxx/ix.sh
@@ -11,5 +11,6 @@ bld/boot/8/lib/linux
 {% endblock %}
 
 {% block bld_deps %}
+bld/boot/5/patch
 bld/boot/7/env/std
 {% endblock %}

--- a/pkgs/lib/c++/13/gcc-13.patch
+++ b/pkgs/lib/c++/13/gcc-13.patch
@@ -1,0 +1,18 @@
+diff --git a/libcxx/include/type_traits b/libcxx/include/type_traits
+index b15c7a2a5f35..0ac6d4d22684 100644
+--- a/libcxx/include/type_traits
++++ b/libcxx/include/type_traits
+@@ -1723,7 +1723,12 @@ struct __is_core_convertible<_Tp, _Up, decltype(
+ 
+ // is_convertible
+ 
+-#if __has_feature(is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
++#if __has_builtin(__is_convertible) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
++
++template <class _T1, class _T2>
++struct _LIBCPP_TEMPLATE_VIS is_convertible : public integral_constant<bool, __is_convertible(_T1, _T2)> {};
++
++#elif __has_feature(is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
+ 
+ template <class _T1, class _T2> struct _LIBCPP_TEMPLATE_VIS is_convertible
+     : public integral_constant<bool, __is_convertible_to(_T1, _T2)> {};

--- a/pkgs/lib/c++/13/gcc/base/ix.sh
+++ b/pkgs/lib/c++/13/gcc/base/ix.sh
@@ -4,3 +4,10 @@
 {{super()}}
 export CXXFLAGS="-std=c++14 ${CXXFLAGS}"
 {% endblock %}
+
+{% block patch %}
+{{super()}}
+patch -p1 << EOF
+{% include '//lib/c++/13/gcc-13.patch' %}
+EOF
+{% endblock %}

--- a/pkgs/lib/c++/bootstrap/t/ix.sh
+++ b/pkgs/lib/c++/bootstrap/t/ix.sh
@@ -24,6 +24,9 @@ cd libcxx
 {% endblock %}
 
 {% block patch %}
+patch -p2 << EOF
+{% include '//lib/c++/13/gcc-13.patch' %}
+EOF
 cat << EOF > include/__config_site
 #pragma once
 


### PR DESCRIPTION
Currently, attempts to build any IX package from a distro with GCC 13 fail like this:
```
> cat Dockerfile.gcc.alpine
FROM alpine:3.20 AS builder
RUN apk add g++ git python3
COPY build_perl.sh /
RUN /build_perl.sh
> cat build_perl.sh
#!/bin/sh
set -eu
mkdir /ix
git clone https://github.com/pg83/ix
export PATH=${PWD}/ix:$PATH
ix build bld/perl
> podman build -f Dockerfile.gcc.alpine --progress=plain
...
In file included from include/__functional/weak_result_type.h:16,
                 from include/__functional/invoke.h:14,
                 from include/concepts:133,
                 from include/__iterator/incrementable_traits.h:14,
                 from include/__iterator/iterator_traits.h:14,
                 from include/__algorithm/search.h:15,
                 from include/functional:490,
                 from include/algorithm:653,
                 from src/algorithm.cpp:9:
include/type_traits:1770:8: error: expected identifier before '__is_convertible'
 1770 | struct __is_convertible
      |        ^~~~~~~~~~~~~~~~
include/type_traits:1770:8: error: expected unqualified-id before '__is_convertible'
include/type_traits:1776:40: error: expected identifier before '__is_convertible'
 1776 | template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 0, 1> : public false_type {};
      |                                        ^~~~~~~~~~~~~~~~
include/type_traits:1776:40: error: expected unqualified-id before '__is_convertible'
include/type_traits:1777:40: error: expected identifier before '__is_convertible'
 1777 | template <class _T1, class _T2> struct __is_convertible<_T1, _T2, 1, 1> : public false_type {};
...
```

This error comes from trying to build `libc++-13` with GCC 13, and this is a known incompatibility which was resolved at some point in [upstream LLVM](https://reviews.llvm.org/D149313). Backport the fix to all known copies of `libc++-13` that are built with the system compiler.