### PR TITLE
Fix bld/boot/2/make guile link failure

### DIFF
--- a/pkgs/bld/boot/2/make/ix.sh
+++ b/pkgs/bld/boot/2/make/ix.sh
@@ -2,6 +2,10 @@
 
 {% block make_no_thrs %}{% endblock %}
 
+{% block configure_flags %}
+--without-guile
+{% endblock %}
+
 {% block bld_libs %}
 bld/boot/1/lib/c
 {% endblock %}


### PR DESCRIPTION
ArchLinux's `make` depends on guile, so it is likely to be installed on
the user system and is catched by `bld/boot/2/make`, which then fails to
find guile libs to link with.
