### PR TITLE
Compile Mesa with RTTI on

### DIFF
--- a/pkgs/lib/mesa/t/ix.sh
+++ b/pkgs/lib/mesa/t/ix.sh
@@ -43,7 +43,6 @@ glx=disabled
 gles2=enabled
 opengl=true
 gallium-nine=false
-cpp_rtti=false
 shader-cache=disabled
 llvm=disabled
 shared-llvm=disabled


### PR DESCRIPTION
Otherwise, we get a mix of RTTI-enabled and RTTI-disabled code for Mesa-dependent binaries. This trips up Address Sanitizer's [ODR detection](https://maskray.me/blog/2022-11-13-odr-violation-detection#lld-comdat-resolution) via COMDAT sections. More specifically, with `-fno-rtti` clang will emit weak typeinfo symbols for an exception whenever it is referenced in a translation unit.

```
> cat a.cc
#include <stdexcept>
int main() {
    throw std::logic_error("");
}
> clang++ -O2 -c a.cc -fno-rtti && nm a.o | c++filt | rg typeinfo
0000000000000000 V typeinfo for std::logic_error
0000000000000000 V typeinfo for std::exception
0000000000000000 V typeinfo name for std::logic_error
0000000000000000 V typeinfo name for std::exception
> clang++ -O2 -c a.cc && nm a.o | c++filt | rg typeinfo
                 U typeinfo for std::logic_error
```