### PR TITLE
Remove --mingetty flag

### DIFF
--- a/pkgs/set/stalix/unwrap/ix.sh
+++ b/pkgs/set/stalix/unwrap/ix.sh
@@ -31,8 +31,6 @@ set/stalix/dns(dns_mngr={{dns_mngr or 'dnsproxy'}})
 
 {% if vt %}
 bin/dm(getty=vt)
-{% elif mingetty %}
-bin/dm(getty=mingetty)
 {% elif emptty %}
 bin/dm(getty=emptty)
 {% else %}


### PR DESCRIPTION
bin/mingetty is deprecated in stal/IX and has known bugs. From https://t.me/stal_ix/2286 and https://t.me/stal_ix/2287:

> But there is a bug with the login prompt: it would appear for about 3 seconds, then disappear, then re-appear for about 3 seconds, then disappear and so on. And when the login prompt is visible, I can't use the keyboard. The `login` command itself is fine, it might be a getty-related bug.

bin/mingetty can stay, but it's time for the --mingetty flag to go.