### PR TITLE
Add hardened IX containers and standalone shitty support

### DIFF
--- a/containers/ix/Dockerfile.builder
+++ b/containers/ix/Dockerfile.builder
@@ -1,0 +1,23 @@
+FROM alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+ARG IX_UID=1000
+ARG IX_GID=1000
+
+RUN apk add --no-cache \
+        bash \
+        ca-certificates \
+        g++ \
+        gcc \
+        git \
+        make \
+        python3 \
+    && mkdir -p /home/ix /src/ix \
+    && chown "${IX_UID}:${IX_GID}" /home/ix /src/ix
+
+COPY --chmod=755 compiler /opt/ix-bootstrap/bin/gcc
+COPY --chmod=755 compiler /opt/ix-bootstrap/bin/g++
+
+USER ${IX_UID}:${IX_GID}
+ENV HOME=/home/ix
+ENV PATH=/opt/ix-bootstrap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+WORKDIR /src/ix

--- a/containers/ix/README.md
+++ b/containers/ix/README.md
@@ -1,0 +1,53 @@
+# Running IX in a container
+
+The container supplies bootstrap tools while all mutable IX data remains on the
+host. `IX_STATE_DIR` is mounted at `/ix` and contains `store`, `build`, `trash`,
+and assembled realms. The repository itself is mounted read-only at `/src/ix`.
+
+Load the dedicated AppArmor profile once after boot:
+
+```sh
+./containers/ix/load_apparmor.sh
+```
+
+Run any IX command with an explicit external state directory:
+
+```sh
+IX_STATE_DIR=/absolute/path/to/ix ./containers/ix/run.sh build bin/shitty
+```
+
+Assemble the system realms in the same external directory:
+
+```sh
+IX_STATE_DIR=/absolute/path/to/ix ./containers/ix/run.sh mut system set/stalix --failsafe --mingetty etc/zram/0
+IX_STATE_DIR=/absolute/path/to/ix ./containers/ix/run.sh mut root set/install
+IX_STATE_DIR=/absolute/path/to/ix ./containers/ix/run.sh mut boot set/boot/all
+```
+
+Converge the system realm using the assembled target tools:
+
+```sh
+IX_CONTAINER_TARGET_ENV=1 IX_STATE_DIR=/absolute/path/to/ix ./containers/ix/run.sh mut system
+```
+
+Import the assembled root as a Docker image. The importer follows `meta.json`
+links from the three realm outputs and copies only that recursive store closure.
+It does not include the source checkout, `build`, `trash`, or unrelated store
+objects. Numeric ownership, modes, hardlinks, ACLs, and extended attributes are
+preserved:
+
+```sh
+IX_STATE_DIR=/absolute/path/to/ix ./containers/ix/import_image.sh shitty
+```
+
+The container drops all outer capabilities and enables `no-new-privileges`.
+Its seccomp profile is derived from the pinned Moby default profile and adds
+only the two namespace masks and exact mount flag combinations used by the IX
+sandbox. AppArmor additionally restricts the mount sources, targets, filesystem
+type, and options. The generated profile is stored next to the state directory
+in `${IX_STATE_DIR}.container` by default.
+
+Creating the profile for the first time requires host Python and access to the
+pinned Moby profile URL. Later runs reuse the verified generated file and do not
+invoke host Python or download the profile again. The Docker builder image
+supplies the bootstrap compilers and Python used by IX itself.

--- a/containers/ix/compiler
+++ b/containers/ix/compiler
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -eu
+
+compiler=${0##*/}
+
+if [ "${compiler}" = gcc ]; then
+    exec /usr/bin/gcc -std=gnu17 -no-pie "$@"
+fi
+
+exec /usr/bin/g++ -no-pie "$@"

--- a/containers/ix/import_image.sh
+++ b/containers/ix/import_image.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${IX_STATE_DIR:-}" ]]; then
+    echo "IX_STATE_DIR must name the external IX root" >&2
+    exit 2
+fi
+
+case "${IX_STATE_DIR}" in
+    /*) ;;
+    *)
+        echo "IX_STATE_DIR must be an absolute path" >&2
+        exit 2
+        ;;
+esac
+
+if [[ ! -d "${IX_STATE_DIR}" ]]; then
+    echo "IX_STATE_DIR does not exist: ${IX_STATE_DIR}" >&2
+    exit 2
+fi
+
+image_tag=${1:-shitty}
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+state_dir=$(CDPATH='' cd -- "${IX_STATE_DIR}" && pwd -P)
+export_image="debian@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818"
+runtime_dir=${IX_CONTAINER_RUNTIME_DIR:-"${state_dir}.container"}
+mkdir -p "${runtime_dir}"
+runtime_dir=$(CDPATH='' cd -- "${runtime_dir}" && pwd -P)
+closure_manifest="${runtime_dir}/image-closure.txt"
+
+python3 "${script_dir}/store_closure.py" "${state_dir}" "${closure_manifest}"
+
+if ! docker image inspect "${export_image}" >/dev/null 2>&1; then
+    docker pull "${export_image}" >/dev/null
+fi
+
+docker run --rm \
+    --cap-drop ALL \
+    --cap-add CHOWN \
+    --cap-add DAC_OVERRIDE \
+    --cap-add FOWNER \
+    --cap-add FSETID \
+    --cap-add SETFCAP \
+    --security-opt no-new-privileges=true \
+    --volume "${state_dir}:/source/ix:ro" \
+    --volume "${closure_manifest}:/closure.txt:ro" \
+    "${export_image}" \
+    sh -eu -c '
+        mkdir -p \
+            /rootfs/etc \
+            /rootfs/ix/realm \
+            /rootfs/ix/store \
+            /rootfs/home/root \
+            /rootfs/var \
+            /rootfs/sys \
+            /rootfs/proc \
+            /rootfs/dev
+        tar \
+            --numeric-owner \
+            --acls \
+            --xattrs \
+            --xattrs-include="*" \
+            -C /source/ix/store \
+            -cf - \
+            -T /closure.txt |
+            tar \
+                --numeric-owner \
+                --same-owner \
+                --same-permissions \
+                --acls \
+                --xattrs \
+                --xattrs-include="*" \
+                -C /rootfs/ix/store \
+                -xf -
+        for realm in system root boot; do
+            ln -s \
+                "$(readlink "/source/ix/realm/${realm}")" \
+                "/rootfs/ix/realm/${realm}"
+        done
+        ln -s /rootfs/ix /ix
+        ln -s ix/realm/system/bin /rootfs/bin
+        ln -s / /rootfs/usr
+        tar \
+            --numeric-owner \
+            --acls \
+            --xattrs \
+            --xattrs-include="*" \
+            -C /ix/realm/system/etc \
+            -cf - \
+            . |
+            tar \
+                --numeric-owner \
+                --same-owner \
+                --same-permissions \
+                --acls \
+                --xattrs \
+                --xattrs-include="*" \
+                -C /rootfs/etc \
+                -xf -
+        tar \
+            --numeric-owner \
+            --acls \
+            --xattrs \
+            --xattrs-include="*" \
+            -C /rootfs \
+            -cf - \
+            .
+    ' |
+    docker import \
+        --change 'WORKDIR /' \
+        - \
+        "${image_tag}"

--- a/containers/ix/ix-container.apparmor
+++ b/containers/ix/ix-container.apparmor
@@ -1,0 +1,26 @@
+#include <tunables/global>
+
+profile ix-container flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network,
+  deny network alg,
+
+  capability sys_admin,
+  file,
+  mount options=(rprivate) -> /,
+  mount fstype=tmpfs options=(rw) tmpfs -> /ix/build/*/,
+  mount options=(bind) /ix/build/**/.trash/ -> /ix/trash/,
+  mount options=(bind) /ix/store/*/ -> /ix/build/**/.shadow/store/*/,
+  remount options=(bind,ro) /ix/build/**/.shadow/store/*/,
+  mount options=(rbind) /ix/build/**/.shadow/store/ -> /ix/store/,
+  userns create,
+
+  signal (receive) peer=unconfined,
+  signal (receive) peer=runc,
+  signal (receive) peer=dockerd,
+  signal (send,receive) peer=ix-container,
+
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+}

--- a/containers/ix/load_apparmor.sh
+++ b/containers/ix/load_apparmor.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+
+exec sudo apparmor_parser -r -K "${script_dir}/ix-container.apparmor"

--- a/containers/ix/run.sh
+++ b/containers/ix/run.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: IX_STATE_DIR=/absolute/path $0 <ix arguments...>" >&2
+    exit 2
+fi
+
+if [ -z "${IX_STATE_DIR:-}" ]; then
+    echo "IX_STATE_DIR must name the external IX root" >&2
+    exit 2
+fi
+
+case "${IX_STATE_DIR}" in
+    /*) ;;
+    *)
+        echo "IX_STATE_DIR must be an absolute path" >&2
+        exit 2
+        ;;
+esac
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+repo_root=$(CDPATH='' cd -- "${script_dir}/../.." && pwd -P)
+
+mkdir -p "${IX_STATE_DIR}"
+state_dir=$(CDPATH='' cd -- "${IX_STATE_DIR}" && pwd -P)
+
+runtime_dir=${IX_CONTAINER_RUNTIME_DIR:-"${state_dir}.container"}
+mkdir -p "${runtime_dir}"
+runtime_dir=$(CDPATH='' cd -- "${runtime_dir}" && pwd -P)
+
+uid=$(id -u)
+gid=$(id -g)
+builder_image="ix-local-builder:${uid}-${gid}"
+seccomp_profile="${runtime_dir}/seccomp-ix-v1.json"
+target_mounts=()
+
+case "${IX_CONTAINER_TARGET_ENV:-0}" in
+    0)
+        exec_kind=local
+        container_path=/opt/ix-bootstrap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        ;;
+    1)
+        exec_kind=system
+        container_path=/ix/realm/root/bin:/ix/realm/system/bin:/ix/realm/boot/bin
+
+        system_realm_link="${state_dir}/realm/system"
+        if [[ ! -L "${system_realm_link}" ]]; then
+            echo "missing assembled system realm: ${system_realm_link}" >&2
+            exit 2
+        fi
+
+        system_realm_target=$(readlink "${system_realm_link}")
+        case "${system_realm_target}" in
+            /ix/*)
+                system_realm_host_target="${state_dir}/${system_realm_target#/ix/}"
+                ;;
+            *)
+                echo "unexpected system realm target: ${system_realm_target}" >&2
+                exit 2
+                ;;
+        esac
+
+        target_bin="${system_realm_host_target}/bin"
+        target_shell="${target_bin}/sh"
+        if [[ -L "${target_shell}" ]]; then
+            target_shell_link=$(readlink "${target_shell}")
+            case "${target_shell_link}" in
+                /ix/*)
+                    target_shell_host="${state_dir}/${target_shell_link#/ix/}"
+                    ;;
+                *)
+                    echo "unexpected system shell target: ${target_shell_link}" >&2
+                    exit 2
+                    ;;
+            esac
+        else
+            target_shell_host="${target_shell}"
+        fi
+
+        if [[ ! -x "${target_shell_host}" ]]; then
+            echo "system realm has no executable shell: ${target_bin}/sh" >&2
+            exit 2
+        fi
+
+        target_mounts+=(
+            --volume "${target_bin}:/bin:ro"
+            --volume "${target_bin}:/usr/bin:ro"
+        )
+        ;;
+    *)
+        echo "IX_CONTAINER_TARGET_ENV must be 0 or 1" >&2
+        exit 2
+        ;;
+esac
+
+if [[ ! -s "${seccomp_profile}" ]]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required to create ${seccomp_profile}" >&2
+        exit 2
+    fi
+    python3 "${script_dir}/seccomp_profile.py" "${seccomp_profile}"
+fi
+
+docker build \
+    --file "${script_dir}/Dockerfile.builder" \
+    --build-arg "IX_UID=${uid}" \
+    --build-arg "IX_GID=${gid}" \
+    --tag "${builder_image}" \
+    "${script_dir}"
+
+docker run --rm --init \
+    --user "${uid}:${gid}" \
+    --cap-drop ALL \
+    --security-opt no-new-privileges=true \
+    --security-opt "apparmor=ix-container" \
+    --security-opt "seccomp=${seccomp_profile}" \
+    "${target_mounts[@]}" \
+    --volume "${state_dir}:/ix:rw" \
+    --volume "${repo_root}:/src/ix:ro" \
+    --env IX_ROOT=/ix \
+    --env "IX_EXEC_KIND=${exec_kind}" \
+    --env "PATH=${container_path}" \
+    --workdir /src/ix \
+    "${builder_image}" \
+    /bin/sh -c '"$@"; status=$?; exit "$status"' ix-container ./ix "$@"

--- a/containers/ix/seccomp_profile.py
+++ b/containers/ix/seccomp_profile.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+import urllib.request
+
+
+DEFAULT_PROFILE_URL = (
+    "https://raw.githubusercontent.com/moby/profiles/refs/tags/"
+    "seccomp/v0.2.3/seccomp/default.json"
+)
+DEFAULT_PROFILE_SHA256 = (
+    "536529b665dd0972c37bfb569f5d4ac8a53592e7b00752bc39ff063ca9864c74"
+)
+
+CLONE_NEWNS = 0x00020000
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWNET = 0x40000000
+
+MS_RDONLY = 0x00000001
+MS_REMOUNT = 0x00000020
+MS_BIND = 0x00001000
+MS_REC = 0x00004000
+MS_PRIVATE = 0x00040000
+
+IX_MOUNT_FLAGS = (
+    0,
+    MS_BIND,
+    MS_BIND | MS_REMOUNT | MS_RDONLY,
+    MS_BIND | MS_REC,
+    MS_PRIVATE | MS_REC,
+)
+
+
+def fetch_default_profile():
+    with urllib.request.urlopen(DEFAULT_PROFILE_URL, timeout=30) as response:
+        content = response.read()
+
+    actual_hash = hashlib.sha256(content).hexdigest()
+    if actual_hash != DEFAULT_PROFILE_SHA256:
+        raise RuntimeError(f"default seccomp profile hash mismatch: {actual_hash}")
+
+    return json.loads(content)
+
+
+def extend_for_ix(profile):
+    syscalls = profile.get("syscalls")
+    if not isinstance(syscalls, list):
+        raise ValueError("default seccomp profile has no syscall list")
+
+    namespace_masks = (
+        CLONE_NEWUSER | CLONE_NEWNS,
+        CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWNET,
+    )
+    for mask in namespace_masks:
+        syscalls.append(
+            {
+                "names": ["unshare"],
+                "action": "SCMP_ACT_ALLOW",
+                "args": [
+                    {
+                        "index": 0,
+                        "value": mask,
+                        "op": "SCMP_CMP_EQ",
+                    }
+                ],
+                "comment": "IX build namespace",
+            }
+        )
+
+    for flags in IX_MOUNT_FLAGS:
+        syscalls.append(
+            {
+                "names": ["mount"],
+                "action": "SCMP_ACT_ALLOW",
+                "args": [
+                    {
+                        "index": 3,
+                        "value": flags,
+                        "op": "SCMP_CMP_EQ",
+                    }
+                ],
+                "comment": "IX sandbox mount operation",
+            }
+        )
+
+    return profile
+
+
+def write_profile(profile, output_path):
+    output_dir = os.path.dirname(os.path.abspath(output_path))
+    os.makedirs(output_dir, exist_ok=True)
+
+    fd, temporary_path = tempfile.mkstemp(
+        dir=output_dir,
+        prefix=".seccomp-",
+        suffix=".json",
+        text=True,
+    )
+    replaced = False
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as output:
+            json.dump(profile, output, indent=2)
+            output.write("\n")
+        os.replace(temporary_path, output_path)
+        replaced = True
+    finally:
+        if not replaced:
+            os.unlink(temporary_path)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output")
+    args = parser.parse_args()
+
+    profile = extend_for_ix(fetch_default_profile())
+    write_profile(profile, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/ix/store_closure.py
+++ b/containers/ix/store_closure.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+
+
+STORE_PREFIX = "/ix/store/"
+STORE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+@=-]*$")
+REALMS = ("system", "root", "boot")
+
+
+def store_name(target):
+    if not isinstance(target, str) or not target.startswith(STORE_PREFIX):
+        raise ValueError(f"invalid store target: {target!r}")
+
+    name = target.removeprefix(STORE_PREFIX)
+    if not STORE_NAME.fullmatch(name):
+        raise ValueError(f"invalid store object name: {name!r}")
+
+    return name
+
+
+def read_links(store_object):
+    metadata = store_object / "meta.json"
+    if not metadata.exists():
+        return ()
+
+    with metadata.open(encoding="utf-8") as source:
+        document = json.load(source)
+
+    links = document.get("links", ())
+    if not isinstance(links, list) or not all(isinstance(link, str) for link in links):
+        raise ValueError(f"invalid links in {metadata}")
+
+    return links
+
+
+def resolve_closure(state_dir):
+    state = Path(state_dir)
+    store = state / "store"
+    realm_dir = state / "realm"
+
+    pending = []
+    for realm in REALMS:
+        realm_link = realm_dir / realm
+        if not realm_link.is_symlink():
+            raise ValueError(f"missing assembled realm: {realm_link}")
+        pending.append(store_name(os.readlink(realm_link)))
+
+    closure = set()
+    while pending:
+        name = pending.pop()
+        if name in closure:
+            continue
+
+        store_object = store / name
+        if store_object.is_symlink() or not store_object.is_dir():
+            raise ValueError(f"missing store object: {store_object}")
+        if not (store_object / "touch").is_file():
+            raise ValueError(f"incomplete store object: {store_object}")
+
+        closure.add(name)
+        for target in read_links(store_object):
+            dependency = store_name(target)
+            if dependency not in closure:
+                pending.append(dependency)
+
+    return sorted(closure)
+
+
+def write_manifest(entries, output_path):
+    destination = Path(output_path).resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_path = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=".image-closure-",
+        suffix=".txt",
+        text=True,
+    )
+    replaced = False
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            for entry in entries:
+                output.write(f"{entry}\n")
+        os.replace(temporary_path, destination)
+        replaced = True
+    finally:
+        if not replaced:
+            os.unlink(temporary_path)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("state_dir")
+    parser.add_argument("output")
+    args = parser.parse_args()
+
+    write_manifest(resolve_closure(args.state_dir), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/containers/ix/test_seccomp_profile.py
+++ b/containers/ix/test_seccomp_profile.py
@@ -1,0 +1,62 @@
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+import seccomp_profile
+
+
+class ExtendForIxTest(unittest.TestCase):
+    def test_adds_only_expected_rules(self):
+        profile = {"syscalls": []}
+
+        result = seccomp_profile.extend_for_ix(profile)
+
+        self.assertIs(result, profile)
+        self.assertEqual(
+            len(result["syscalls"]),
+            2 + len(seccomp_profile.IX_MOUNT_FLAGS),
+        )
+        self.assertEqual(
+            result["syscalls"][0]["args"][0]["value"],
+            seccomp_profile.CLONE_NEWUSER | seccomp_profile.CLONE_NEWNS,
+        )
+        self.assertEqual(
+            result["syscalls"][1]["args"][0]["value"],
+            seccomp_profile.CLONE_NEWUSER
+            | seccomp_profile.CLONE_NEWNS
+            | seccomp_profile.CLONE_NEWNET,
+        )
+        mount_rules = result["syscalls"][2:]
+        self.assertEqual(
+            [rule["names"] for rule in mount_rules],
+            [["mount"]] * len(seccomp_profile.IX_MOUNT_FLAGS),
+        )
+        self.assertEqual(
+            [rule["args"][0]["index"] for rule in mount_rules],
+            [3] * len(seccomp_profile.IX_MOUNT_FLAGS),
+        )
+        self.assertEqual(
+            [rule["args"][0]["value"] for rule in mount_rules],
+            list(seccomp_profile.IX_MOUNT_FLAGS),
+        )
+        self.assertEqual(
+            [rule["args"][0]["op"] for rule in mount_rules],
+            ["SCMP_CMP_EQ"] * len(seccomp_profile.IX_MOUNT_FLAGS),
+        )
+        added_names = {name for rule in result["syscalls"] for name in rule["names"]}
+        self.assertNotIn("pivot_root", added_names)
+        self.assertNotIn("umount", added_names)
+        self.assertNotIn("umount2", added_names)
+        self.assertTrue(
+            all(rule["action"] == "SCMP_ACT_ALLOW" for rule in result["syscalls"])
+        )
+
+    def test_rejects_missing_syscall_list(self):
+        with self.assertRaisesRegex(ValueError, "no syscall list"):
+            seccomp_profile.extend_for_ix({})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/containers/ix/test_store_closure.py
+++ b/containers/ix/test_store_closure.py
@@ -1,0 +1,89 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from store_closure import resolve_closure, write_manifest
+
+
+class StoreClosureTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.state = Path(self.temporary.name)
+        (self.state / "store").mkdir()
+        (self.state / "realm").mkdir()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def add_store_object(self, name, links=()):
+        store_object = self.state / "store" / name
+        store_object.mkdir()
+        (store_object / "touch").touch()
+        (store_object / "meta.json").write_text(
+            json.dumps({"links": list(links)}),
+            encoding="utf-8",
+        )
+
+    def test_resolves_only_recursive_realm_closure(self):
+        self.add_store_object(
+            "system",
+            ("/ix/store/runtime", "/ix/store/shared"),
+        )
+        self.add_store_object("root", ("/ix/store/shared",))
+        self.add_store_object("boot")
+        self.add_store_object("runtime", ("/ix/store/transitive",))
+        self.add_store_object("shared")
+        self.add_store_object("transitive")
+        self.add_store_object("unrelated")
+
+        for realm in ("system", "root", "boot"):
+            os.symlink(
+                f"/ix/store/{realm}",
+                self.state / "realm" / realm,
+            )
+
+        (self.state / "build").mkdir()
+        (self.state / "build" / "sentinel").touch()
+        (self.state / "trash").mkdir()
+        (self.state / "trash" / "sentinel").touch()
+
+        closure = resolve_closure(self.state)
+
+        self.assertEqual(
+            closure,
+            [
+                "boot",
+                "root",
+                "runtime",
+                "shared",
+                "system",
+                "transitive",
+            ],
+        )
+        self.assertNotIn("unrelated", closure)
+
+    def test_rejects_store_path_traversal(self):
+        self.add_store_object("system", ("/ix/store/../secret",))
+        self.add_store_object("root")
+        self.add_store_object("boot")
+        for realm in ("system", "root", "boot"):
+            os.symlink(
+                f"/ix/store/{realm}",
+                self.state / "realm" / realm,
+            )
+
+        with self.assertRaisesRegex(ValueError, "invalid store object name"):
+            resolve_closure(self.state)
+
+    def test_writes_sorted_manifest(self):
+        destination = self.state / "runtime" / "closure.txt"
+
+        write_manifest(["a", "b"], destination)
+
+        self.assertEqual(destination.read_text(encoding="utf-8"), "a\nb\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkgs/bin/shitty/fontconfig-face-index.patch
+++ b/pkgs/bin/shitty/fontconfig-face-index.patch
@@ -1,0 +1,165 @@
+diff --git a/font.cpp b/font.cpp
+index 2758b1b..0c10f9e 100644
+--- a/font.cpp
++++ b/font.cpp
+@@ -29,2 +29,2 @@ using namespace stl;
+-Font::Font(const std::string& filename_)
+-    : filename(filename_)
++Font::Font(const FontFace& font_)
++    : font(font_)
+@@ -36,2 +36,2 @@ Font::Font(const std::string& filename_)
+-Font::Font(const std::string& filename_, const Font& priFont, Overlay_)
+-    : filename(filename_)
++Font::Font(const FontFace& font_, const Font& priFont, Overlay_)
++    : font(font_)
+@@ -50,2 +50,2 @@ Font::Font(const std::string& filename_, const Font& priFont, Overlay_)
+-Font::Font(const std::string& filename_, const Font& priFont, DoubleWidth_)
+-    : filename(filename_)
++Font::Font(const FontFace& font_, const Font& priFont, DoubleWidth_)
++    : font(font_)
+@@ -92,3 +92,4 @@ void Font::load() {
+-    logI << "Loading " << filename << " as " << (overlay ? "overlay" : (dwidth ? "double-width" : "primary")) << std::endl;
+-    if (FT_New_Face(ft, filename.c_str(), 0, &face)) {
+-        throw std::runtime_error(std::string("Failed to load font ") + filename);
++    logI << "Loading " << font.filename << " (face " << font.index << ") as "
++         << (overlay ? "overlay" : (dwidth ? "double-width" : "primary")) << std::endl;
++    if (FT_New_Face(ft, font.filename.c_str(), font.index, &face)) {
++        throw std::runtime_error(std::string("Failed to load font ") + font.filename);
+@@ -201 +202 @@ void Font::loadFixed(const FT_Face& face) {
+-            throw std::runtime_error(filename + ": size mismatch, expected px=" + std::to_string(px) + ", got: " + std::to_string(facesize.width));
++            throw std::runtime_error(font.filename + ": size mismatch, expected px=" + std::to_string(px) + ", got: " + std::to_string(facesize.width));
+@@ -204 +205 @@ void Font::loadFixed(const FT_Face& face) {
+-            throw std::runtime_error(filename + ": size mismatch, expected py=" + std::to_string(py) + ", got: " + std::to_string(facesize.height));
++            throw std::runtime_error(font.filename + ": size mismatch, expected py=" + std::to_string(py) + ", got: " + std::to_string(facesize.height));
+@@ -229 +230,7 @@ void Font::loadScaled(const FT_Face& face) {
+-    double tpy = tpx * face->height / face->max_advance_width + 1;
++    const FT_ULong widthCodepoint = dwidth ? 0x3000 : 'M';
++    if (FT_Get_Char_Index(face, widthCodepoint) != 0 &&
++        FT_Load_Char(face, widthCodepoint, FT_LOAD_DEFAULT) == 0 &&
++        face->glyph->advance.x > 0) {
++        tpx = face->glyph->advance.x / 64.0;
++    }
++    double tpy = opts.fontsize * (double)face->height / face->units_per_EM + 1;
+@@ -234 +241 @@ void Font::loadScaled(const FT_Face& face) {
+-        throw std::runtime_error(filename + ": scaled metric mismatch, expected " + std::to_string(px) + "x" + std::to_string(py) + ", got " + std::to_string(facePx) + "x" + std::to_string(facePy));
++        throw std::runtime_error(font.filename + ": scaled metric mismatch, expected " + std::to_string(px) + "x" + std::to_string(py) + ", got " + std::to_string(facePx) + "x" + std::to_string(facePy));
+@@ -237 +244 @@ void Font::loadScaled(const FT_Face& face) {
+-        throw std::runtime_error(filename + ": scaled baseline mismatch, expected " + std::to_string(baseline) + ", got " + std::to_string(faceBaseline));
++        throw std::runtime_error(font.filename + ": scaled baseline mismatch, expected " + std::to_string(baseline) + ", got " + std::to_string(faceBaseline));
+diff --git a/font.h b/font.h
+index 1285d7c..6f7f7b0 100644
+--- a/font.h
++++ b/font.h
+@@ -12,0 +13,2 @@
++#include "font_resolver.h"
++
+@@ -36 +38 @@ public:
+-    explicit Font(const std::string& filename);
++    explicit Font(const FontFace& font);
+@@ -48 +50 @@ public:
+-    Font(const std::string& filename, const Font& priFont, Overlay_);
++    Font(const FontFace& font, const Font& priFont, Overlay_);
+@@ -58 +60 @@ public:
+-    Font(const std::string& filename, const Font& priFont, DoubleWidth_);
++    Font(const FontFace& font, const Font& priFont, DoubleWidth_);
+@@ -102 +104 @@ private:
+-    std::string filename;
++    FontFace font;
+diff --git a/font_resolver.cpp b/font_resolver.cpp
+index 248f334..eab040d 100644
+--- a/font_resolver.cpp
++++ b/font_resolver.cpp
+@@ -19 +19 @@ namespace {
+-    std::string fontconfigFile(const std::string& family, int weight, int slant) {
++    FontFace fontconfigFace(const std::string& family, int weight, int slant) {
+@@ -21 +21 @@ namespace {
+-            return {};
++            return FontFace{};
+@@ -25 +25 @@ namespace {
+-            return {};
++            return FontFace{};
+@@ -36 +36 @@ namespace {
+-            return {};
++            return FontFace{};
+@@ -39 +39 @@ namespace {
+-        std::string path;
++        FontFace face;
+@@ -41 +41,2 @@ namespace {
+-            path = (const char*)(file);
++            face.filename = (const char*)(file);
++            FcPatternGetInteger(match, FC_INDEX, 0, &face.index);
+@@ -44 +45 @@ namespace {
+-        return path;
++        return face;
+@@ -50 +51 @@ FontVariants resolveFontconfig(const std::string& family) {
+-    variants.regular = fontconfigFile(family, FC_WEIGHT_REGULAR, FC_SLANT_ROMAN);
++    variants.regular = fontconfigFace(family, FC_WEIGHT_REGULAR, FC_SLANT_ROMAN);
+@@ -54,3 +55,3 @@ FontVariants resolveFontconfig(const std::string& family) {
+-    std::string path = fontconfigFile(family, FC_WEIGHT_BOLD, FC_SLANT_ROMAN);
+-    if (!path.empty() && path != variants.regular) {
+-        variants.bold = path;
++    FontFace face = fontconfigFace(family, FC_WEIGHT_BOLD, FC_SLANT_ROMAN);
++    if (!face.empty() && face != variants.regular) {
++        variants.bold = face;
+@@ -58,3 +59,3 @@ FontVariants resolveFontconfig(const std::string& family) {
+-    path = fontconfigFile(family, FC_WEIGHT_REGULAR, FC_SLANT_ITALIC);
+-    if (!path.empty() && path != variants.regular) {
+-        variants.italic = path;
++    face = fontconfigFace(family, FC_WEIGHT_REGULAR, FC_SLANT_ITALIC);
++    if (!face.empty() && face != variants.regular) {
++        variants.italic = face;
+@@ -62,3 +63,3 @@ FontVariants resolveFontconfig(const std::string& family) {
+-    path = fontconfigFile(family, FC_WEIGHT_BOLD, FC_SLANT_ITALIC);
+-    if (!path.empty() && path != variants.regular && path != variants.bold && path != variants.italic) {
+-        variants.boldItalic = path;
++    face = fontconfigFace(family, FC_WEIGHT_BOLD, FC_SLANT_ITALIC);
++    if (!face.empty() && face != variants.regular && face != variants.bold && face != variants.italic) {
++        variants.boldItalic = face;
+diff --git a/font_resolver.h b/font_resolver.h
+index 14fd6ba..c1bb069 100644
+--- a/font_resolver.h
++++ b/font_resolver.h
+@@ -4,0 +5,17 @@
++struct FontFace {
++    std::string filename;
++    int index = 0;
++
++    bool empty() const {
++        return filename.empty();
++    }
++
++    bool operator==(const FontFace& other) const {
++        return filename == other.filename && index == other.index;
++    }
++
++    bool operator!=(const FontFace& other) const {
++        return !(*this == other);
++    }
++};
++
+@@ -6,4 +23,4 @@ struct FontVariants {
+-    std::string regular;
+-    std::string bold;
+-    std::string italic;
+-    std::string boldItalic;
++    FontFace regular;
++    FontFace bold;
++    FontFace italic;
++    FontFace boldItalic;
+diff --git a/options.cpp b/options.cpp
+index 3a42e74..088a080 100644
+--- a/options.cpp
++++ b/options.cpp
+@@ -60 +60 @@ namespace {
+-        {"dwfont", OptionKind::SepArg, nullptr, "18x18ja", "Double-width font to use"},
++        {"dwfont", OptionKind::SepArg, nullptr, "Sarasa Term Slab CL", "Double-width font to use"},
+@@ -62 +62 @@ namespace {
+-        {"font", OptionKind::SepArg, nullptr, "monospace", "Font to use"},
++        {"font", OptionKind::SepArg, nullptr, "Sarasa Term Slab CL", "Font to use"},
+diff --git a/test_mode.cpp b/test_mode.cpp
+index 96fd854..912a132 100644
+--- a/test_mode.cpp
++++ b/test_mode.cpp
+@@ -875 +875 @@ int runTestMode(Composer& composer, TestModeInput& input, int controlFd, int arg
+-                const std::string encoded = variants.regular + '\0' + variants.bold + '\0' + variants.italic + '\0' + variants.boldItalic;
++                const std::string encoded = variants.regular.filename + '\0' + variants.bold.filename + '\0' + variants.italic.filename + '\0' + variants.boldItalic.filename;

--- a/pkgs/bin/shitty/ix.sh
+++ b/pkgs/bin/shitty/ix.sh
@@ -24,6 +24,12 @@ zutty
 git config submodule.third_party/libstd.url https://github.com/pg83/std.git
 {% endblock %}
 
+{% block patch %}
+patch -p1 << 'EOF'
+{% include 'fontconfig-face-index.patch' %}
+EOF
+{% endblock %}
+
 {% block bld_libs %}
 lib/c
 lib/glfw

--- a/pkgs/lib/amd/radv/driver/dl/ix.sh
+++ b/pkgs/lib/amd/radv/driver/dl/ix.sh
@@ -16,5 +16,5 @@ radv_
 {% endblock %}
 
 {% block export_lib %}
-vulkan_swiftshader
+vulkan_radeon
 {% endblock %}


### PR DESCRIPTION
## Summary

- add Docker build/run/import helpers that keep mutable IX state outside the image and allow only the namespace and mount operations used by the IX sandbox
- import only the recursive realm store closure while preserving ownership, modes, hardlinks, ACLs, and extended attributes
- make `shitty` resolve the correct Sarasa Term Slab CL TTC face and cell metrics, and export the correct RADV Vulkan driver key for standalone host execution

## Verification

- built `bin/shitty` through the secured container workflow
- ran the standalone binary against host Fontconfig, locale, and AMD RADV Vulkan data
- verified seccomp/AppArmor negative probes for disallowed mount, unmount, pivot-root, and chroot operations
- imported and smoke-tested a 176-object image closure
- compared metadata for 60,837 source/image paths, including 907 hardlink groups
- ran Ruff, ShellCheck, Bash syntax checks, AppArmor parser checks, and 5 focused pytest tests
